### PR TITLE
add @options[:udp_port] to definition for runit template

### DIFF
--- a/definitions/memcached_instance.rb
+++ b/definitions/memcached_instance.rb
@@ -28,11 +28,12 @@ define :memcached_instance do
     default_logger    true
     cookbook          'memcached'
     options({
-      :memory  => node['memcached']['memory'],
-      :port    => node['memcached']['port'],
-      :listen  => node['memcached']['listen'],
-      :maxconn => node['memcached']['maxconn'],
-      :user    => node['memcached']['user']
+      :memory   => node['memcached']['memory'],
+      :port     => node['memcached']['port'],
+      :udp_port => node['memcached']['udp_port'],
+      :listen   => node['memcached']['listen'],
+      :maxconn  => node['memcached']['maxconn'],
+      :user     => node['memcached']['user']
     }.merge(opts))
   end
 end


### PR DESCRIPTION
udp_port was missing in the define but was present in the template. Having no value here resulted in a memcached command line like:
```
/usr/bin/memcached -v -m 64 -U -p 11211 -u nobody -l 0.0.0.0 -c 1024
```
Instead of:
```
/usr/bin/memcached -v -m 64 -U 11211 -p 11211 -u nobody -l 0.0.0.0 -c 1024
```
So memcached was starting, but not listening on UDP (OR TCP).