### PR TITLE
Update default.rb

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -40,7 +40,7 @@ package 'libmemcache-dev' do
 end
 
 service 'memcached' do
-  action :enable
+  action [:enable, :start]
   supports :status => true, :start => true, :stop => true, :restart => true, :enable => true
 end
 
@@ -69,7 +69,7 @@ when 'smartos'
   # SMF directly configures memcached with no opportunity to alter settings
   # If you need custom parameters, use the memcached_instance provider
   service 'memcached' do
-    action :enable
+    action [:enable, :start]
   end
 else
   template '/etc/memcached.conf' do


### PR DESCRIPTION
Added ":start" action for memcached service, to fix the scenario in openstack cookbbook:
In openstack, identity service depends on memcached service. But after the memcached package was installed, before service was started, the identity service started serving already, this caused the identity service can not work properly. In this case, we should make ensure the memcached service starts immediately.