### PR TITLE
Be able to change the logfile location for memcached.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -85,6 +85,7 @@ else
       :maxconn         => node['memcached']['maxconn'],
       :memory          => node['memcached']['memory'],
       :max_object_size => node['memcached']['max_object_size']
+      :logfilename     => node['memcached']['logfilename']
     )
     notifies :restart, 'service[memcached]'
   end

--- a/templates/default/memcached.conf.erb
+++ b/templates/default/memcached.conf.erb
@@ -11,8 +11,12 @@
 # information.
 -d
 
-# Log memcached's output to /var/log/memcached
+# Log memcached's output to /var/log/memcached.log
+<%- if @logfilename %>
+logfile /var/log/<%= @logfilename %>
+<%- else %>
 logfile /var/log/memcached.log
+<%- end %>
 
 # Be verbose
 -v


### PR DESCRIPTION
I was unable to specify my own logfile name/location. Debian had a small inconsistency based on the docs:

`memcached['logfilename']` - logfile to which memcached output will be redirected in /var/log/$logfilename.

Although I removed the /var/log/$logfilename location to a full path.