### PR TITLE
Debian package name ends in a 'd'.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -34,6 +34,8 @@ package 'libmemcache-dev' do
     else
       package_name 'libmemcached-devel'
     end
+  when 'debian'
+    package_name 'libmemcached-dev'
   else
     package_name 'libmemcache-dev'
   end


### PR DESCRIPTION
After having issues where pylibmc couldn't access memcached on Ubuntu 14.04LTS (it specifically wants to compile using `#include <libmemcached/memcached.h>`, I tracked it down to libmemcached-dev not being installed; this cookbook installs libmemcache-dev rather than libmemcached-dev on Debian systems. While both exist, this attempts to install the package ending in 'd' on other platforms. (On Fedora for example both also exist but this installs http://www.rpmfind.net/linux/rpm2html/search.php?query=libmemcached-devel rather than http://www.rpmfind.net/linux/rpm2html/search.php?query=libmemcache-devel.)

libmemcached-dev packages:

- [Package on Ubuntu Packages](http://packages.ubuntu.com/trusty/libmemcached-dev).
- [Package on Debian Packages](https://packages.debian.org/sid/libmemcached-dev)
- [Package List on RPM Find](http://www.rpmfind.net/linux/rpm2html/search.php?query=libmemcached-devel)

libmemcache-dev packages:

- [Package on Ubuntu Packages](http://packages.ubuntu.com/trusty/libmemcache-dev)
- [Package on Debian Packages](https://packages.debian.org/sid/libmemcache-dev)
- [Package List on RPM Find](http://www.rpmfind.net/linux/rpm2html/search.php?query=libmemcache-devel)