### PR TITLE
Update broken tests for Berks3/Serverspec2

### DIFF
--- a/.kitchen.cloud.yml
+++ b/.kitchen.cloud.yml
@@ -1,0 +1,72 @@
+---
+driver_plugin: vagrant
+driver_plugin: digitalocean
+driver_config:
+  digitalocean_client_id: <%= ENV['DIGITAL_OCEAN_CLIENT_ID'] %>
+  digitalocean_api_key: <%= ENV['DIGITAL_OCEAN_API_KEY'] %>
+  aws_access_key_id: <%= ENV['AWS_ACCESS_KEY_ID'] %> 
+  aws_secret_access_key: <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
+  aws_ssh_key_id: <%= ENV['AWS_KEYPAIR_NAME'] %>
+  ssh_key: <%= ENV['AWS_PRIVATE_KEY_PATH'] %>
+  rackspace_username: <%= ENV['RACKSPACE_USERNAME'] %>
+  rackspace_api_key: <%= ENV['RACKSPACE_API_KEY'] %>
+  require_chef_omnibus: latest
+
+platforms:
+- name: centos-5.8
+  driver_plugin: digitalocean
+  driver_config:
+    image_id: 1601
+    flavor_id: 63
+    region_id: 1
+    ssh_key_ids: <%= ENV['DIGITAL_OCEAN_SSH_KEY_IDS'] %>
+
+- name: centos-6.4
+  driver_plugin: digitalocean
+  driver_config:
+    image_id: 562354
+    flavor_id: 63
+    region_id: 1
+    ssh_key_ids: <%= ENV['DIGITAL_OCEAN_SSH_KEY_IDS'] %>
+
+- name: amazon-2013.09
+  driver_plugin: ec2
+  driver_config:
+    image_id: ami-3be4bc52
+    username: ec2-user
+
+# - name: fedora-19
+#   driver_plugin: digitalocean
+#   driver_config:
+#     image_id: 696598
+#     flavor_id: 63
+#     region_id: 1
+#     ssh_key_ids: <%= ENV['DIGITAL_OCEAN_SSH_KEY_IDS'] %>
+
+- name: ubuntu-1004
+  driver_plugin: digitalocean
+  driver_config:
+    image_id: 14097
+    flavor_id: 63
+    region_id: 1
+    ssh_key_ids: <%= ENV['DIGITAL_OCEAN_SSH_KEY_IDS'] %>
+  run_list:
+  - recipe[apt]
+
+- name: ubuntu-1204
+  driver_plugin: digitalocean
+  driver_config:
+    image_id: 1505447
+    flavor_id: 63
+    region_id: 1
+    ssh_key_ids: <%= ENV['DIGITAL_OCEAN_SSH_KEY_IDS'] %>
+  run_list:
+  - recipe[apt]
+
+suites:
+  - name: default
+    run_list:
+      - recipe[memcached::default]
+  - name: instance
+    run_list:
+      - recipe[fake::instance]

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,65 +1,23 @@
 ---
 driver_plugin: vagrant
-driver_plugin: digitalocean
-driver_config:
-  digitalocean_client_id: <%= ENV['DIGITAL_OCEAN_CLIENT_ID'] %>
-  digitalocean_api_key: <%= ENV['DIGITAL_OCEAN_API_KEY'] %>
-  aws_access_key_id: <%= ENV['AWS_ACCESS_KEY_ID'] %> 
-  aws_secret_access_key: <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
-  aws_ssh_key_id: <%= ENV['AWS_KEYPAIR_NAME'] %>
-  ssh_key: <%= ENV['AWS_PRIVATE_KEY_PATH'] %>
-  rackspace_username: <%= ENV['RACKSPACE_USERNAME'] %>
-  rackspace_api_key: <%= ENV['RACKSPACE_API_KEY'] %>
-  require_chef_omnibus: latest
+
+provisioner:
+  name: chef_zero
 
 platforms:
-- name: centos-5.8
-  driver_plugin: digitalocean
-  driver_config:
-    image_id: 1601
-    flavor_id: 63
-    region_id: 1
-    ssh_key_ids: <%= ENV['DIGITAL_OCEAN_SSH_KEY_IDS'] %>
+- name: centos-5.10
 
-- name: centos-6.4
-  driver_plugin: digitalocean
-  driver_config:
-    image_id: 562354
-    flavor_id: 63
-    region_id: 1
-    ssh_key_ids: <%= ENV['DIGITAL_OCEAN_SSH_KEY_IDS'] %>
+- name: centos-6.6
 
-- name: amazon-2013.09
-  driver_plugin: ec2
-  driver_config:
-    image_id: ami-3be4bc52
-    username: ec2-user
-
-# - name: fedora-19
-#   driver_plugin: digitalocean
-#   driver_config:
-#     image_id: 696598
-#     flavor_id: 63
-#     region_id: 1
-#     ssh_key_ids: <%= ENV['DIGITAL_OCEAN_SSH_KEY_IDS'] %>
-
-- name: ubuntu-1004
-  driver_plugin: digitalocean
-  driver_config:
-    image_id: 14097
-    flavor_id: 63
-    region_id: 1
-    ssh_key_ids: <%= ENV['DIGITAL_OCEAN_SSH_KEY_IDS'] %>
+- name: ubuntu-10.04
   run_list:
   - recipe[apt]
 
-- name: ubuntu-1204
-  driver_plugin: digitalocean
-  driver_config:
-    image_id: 1505447
-    flavor_id: 63
-    region_id: 1
-    ssh_key_ids: <%= ENV['DIGITAL_OCEAN_SSH_KEY_IDS'] %>
+- name: ubuntu-12.04
+  run_list:
+  - recipe[apt]
+
+- name: ubuntu-14.04
   run_list:
   - recipe[apt]
 

--- a/Berksfile
+++ b/Berksfile
@@ -1,4 +1,4 @@
-site 'https://supermarket.chef.io'
+source 'https://supermarket.chef.io'
 metadata
 
 group :integration do

--- a/test/integration/helpers/serverspec/spec_helper.rb
+++ b/test/integration/helpers/serverspec/spec_helper.rb
@@ -1,0 +1,3 @@
+require 'serverspec'
+
+set :backend, :exec

--- a/test/integration/instance/serverspec/instance_spec.rb
+++ b/test/integration/instance/serverspec/instance_spec.rb
@@ -1,10 +1,15 @@
-require 'serverspec'
-include Serverspec::Helper::Exec
-include Serverspec::Helper::DetectOS
+require 'spec_helper'
+set :path, '$PATH:/sbin' if os[:family] == 'redhat' && os[:release].match(/^5\.\d+/)
 
-describe 'memcached_instance definition' do
-  it 'is running with the correct attributes' do
-    expect(service('memcached')).to be_running
-    expect(port(11_211)).to be_listening
-  end
+describe package('memcached') do
+  it { should be_installed }
+end
+
+describe service('memcached') do
+  it { should be_enabled }
+  it { should be_running }
+end
+
+describe port(11211) do
+  it { should be_listening.with('tcp') }
 end


### PR DESCRIPTION
Current .kitchen.yml, Berksfile, and serverspec files require updates
to allow "kitchen test" to complete.

- moved current .kitchen.yml file to .kitchen.cloud.yml to avoid cloud
  provider missing key errors
- created a new .kitchen.yml file using vagrant driver, chef_zero
  provisioner, updated centos platforms, and added ubuntu-14.04
- updated Berksfile to use source location as site location has been
  deprecated in Berkshelf 3
- updated instance_spec.rb for Serverspec V2 and added a few more
  simple tests